### PR TITLE
Remove nav white bg (redo with cleaner branch)

### DIFF
--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -1,7 +1,9 @@
 export const Logo = ({ fill = "#1b1917" }) => (
   <div className="logo">
     <span className="P">P</span>
-    <span className="letters">oetry</span>
+    <span>
+      <span className="letters">oetry</span>
+    </span>
     <svg
       width="32"
       height="52"

--- a/src/styles/base/colors.css
+++ b/src/styles/base/colors.css
@@ -1,5 +1,6 @@
 :root {
   --white: #fffcf5;
+  --white-75: #fffcf5bf;
   --black: #1b1917;
   --yellow: #fdd63c;
   --red: #eb2700;

--- a/src/styles/components/nav.css
+++ b/src/styles/components/nav.css
@@ -19,7 +19,6 @@
   left: 0;
   right: 0;
   z-index: 100;
-  background: rgba(255, 255, 255, 0.75);
   backdrop-filter: blur(10px);
   row-gap: 0.4rem;
 
@@ -59,7 +58,6 @@
 
   /* &.open,
   &.subnav-open {
-    background: rgba(255, 255, 255, 0.75);
     height: auto;
     backdrop-filter: blur(10px);
     position: fixed;

--- a/src/styles/components/nav.css
+++ b/src/styles/components/nav.css
@@ -1,13 +1,13 @@
 @keyframes logo-timeline {
   0% {
-    --logo-letter-ml: 0px;
+    --logo-letter-ml: 0ch;
     opacity: 1;
   }
   90% {
     opacity: 0;
   }
   100% {
-    --logo-letter-ml: -45px;
+    --logo-letter-ml: -3.72ch;
     opacity: 0;
   }
 }
@@ -20,6 +20,7 @@
   right: 0;
   z-index: 100;
   backdrop-filter: blur(10px);
+  background-color: var(--white-75);
   row-gap: 0.4rem;
 
   &.loading {
@@ -39,9 +40,8 @@
     width: fit-content;
     overflow-x: clip;
 
-    .P {
-      background-color: var(--white);
-      z-index: 1;
+    .P ~ span {
+      overflow: clip;
     }
 
     .letters {

--- a/src/styles/components/video-player.css
+++ b/src/styles/components/video-player.css
@@ -100,6 +100,7 @@
     padding: 0.8rem 0;
     opacity: 0;
     pointer-events: none;
+    background-color: var(--white-75);
     backdrop-filter: blur(10px);
     transition: opacity 0.1s ease, transform 0.3s ease;
 

--- a/src/styles/components/video-player.css
+++ b/src/styles/components/video-player.css
@@ -97,7 +97,6 @@
     right: 0;
     transform: translateY(50%);
     z-index: 10;
-    background: rgba(255, 255, 255, 0.75);
     padding: 0.8rem 0;
     opacity: 0;
     pointer-events: none;

--- a/src/styles/pages/page.css
+++ b/src/styles/pages/page.css
@@ -7,7 +7,6 @@
     position: sticky;
     top: var(--nav-height);
     grid-column: 1 / -1;
-    background: rgba(255, 255, 255, 0.75);
     backdrop-filter: blur(10px);
     padding: 1px 1.2rem 4px 1.2rem;
     margin: 0 -1.2rem;

--- a/src/styles/pages/page.css
+++ b/src/styles/pages/page.css
@@ -7,6 +7,7 @@
     position: sticky;
     top: var(--nav-height);
     grid-column: 1 / -1;
+    background-color: var(--white-75);
     backdrop-filter: blur(10px);
     padding: 1px 1.2rem 4px 1.2rem;
     margin: 0 -1.2rem;


### PR DESCRIPTION
1. Fix 3 elements had white backgrounds on the (almost) white page background. Hard to see, but visible on high quality displays.
2. Fix the logo animation on mobile which didn't account for responsive font sizes.
3. Fix the logo animation where the P had an opaque background which didn't blend in with the blurred mobile menu when scrolling

| Before | After |
|-------|-------|
| <img width="78" height="48" alt="image" src="https://github.com/user-attachments/assets/3c72c64f-b646-4849-b0f4-5a8b4e54d2f6" /> | <img width="220" height="101" alt="image" src="https://github.com/user-attachments/assets/6ed651f9-edb2-45d0-a10a-a8c2168b26aa" /> |
