### PR TITLE
fix: align nav inside the search

### DIFF
--- a/src/styles/components/search.css
+++ b/src/styles/components/search.css
@@ -35,6 +35,11 @@
 
   .nav {
     position: static;
+    background-color: transparent;
+
+    .logo-wrapper {
+      grid-column: 1 / 2;
+    }
   }
 
   .search--input {


### PR DESCRIPTION
Fixes a misalignment of the nav inside the search on desktop.

Before: 
<img width="1792" height="202" alt="image" src="https://github.com/user-attachments/assets/9268b3ec-a8bf-41a5-8b4d-db9e18001813" />


After:
<img width="1792" height="178" alt="image" src="https://github.com/user-attachments/assets/07d67889-29be-4b29-876b-27648411c55b" />
