### PR TITLE
perf: only load youtube iframes after clicking play

### DIFF
--- a/src/components/VideoPlayer.jsx
+++ b/src/components/VideoPlayer.jsx
@@ -38,13 +38,13 @@ export const VideoPlayer = ({ video }) => {
     return (
       <div className="video-player">
         <div className="video">
-          {videoPlayerUrl && (
+          {videoPlayerUrl && isPlaying && (
             <iframe
               src={videoPlayerUrl}
               alt=""
-              frameBorder="0"
               allow="autoplay"
               allowFullScreen
+              title={title}
             />
           )}
           <div
@@ -66,7 +66,7 @@ export const VideoPlayer = ({ video }) => {
                 description && setShowDescription(!showDescription)
               }
               aria-label="Toggle video description"
-              aria-expanded={description}
+              aria-expanded={showDescription}
             >
               <div className="title__title">
                 <h3>{title}</h3>
@@ -94,9 +94,9 @@ export const VideoPlayer = ({ video }) => {
           <iframe
             src={videoPlayerUrl}
             alt=""
-            frameBorder="0"
             allow="autoplay"
             allowFullScreen
+            title={title}
           />
         )}
         <div className={`overlay ${isPlaying ? "playing" : ""}`}>
@@ -136,7 +136,7 @@ export const VideoPlayer = ({ video }) => {
                   description && setShowDescription(!showDescription)
                 }
                 aria-label="Toggle video description"
-                aria-expanded={description}
+                aria-expanded={showDescription}
               >
                 <div className="title__title">
                   <h3>{title}</h3>


### PR DESCRIPTION
1. only load youtube iframes after clicking play
2. fixed invalid values for aria-expanded
3. add titles to YT iframes

0 a11y issues in Axe Dev tools! 

<img width="601" height="832" alt="image" src="https://github.com/user-attachments/assets/04a42e5d-a160-4f7b-ad98-9b96a3ed2bbb" />
